### PR TITLE
Load deferred file attachments as well

### DIFF
--- a/models/Wpimporter.php
+++ b/models/Wpimporter.php
@@ -142,7 +142,7 @@ class Wpimporter extends Model
 
         if (! empty($this->import_xml_file)) {
             set_time_limit(360);
-            $importFileContent = $this->import_xml_file()->withDeferred(input('_session_key')->first()->getContents();
+            $importFileContent = $this->import_xml_file()->withDeferred(input('_session_key'))->first()->getContents();
 
             //Defaults
             $replaceArray = Wpimporter::get('replace_array');

--- a/models/Wpimporter.php
+++ b/models/Wpimporter.php
@@ -142,7 +142,7 @@ class Wpimporter extends Model
 
         if (! empty($this->import_xml_file)) {
             set_time_limit(360);
-            $importFileContent = $this->import_xml_file->getContents();
+            $importFileContent = $this->import_xml_file()->withDeferred(input('_session_key')->first()->getContents();
 
             //Defaults
             $replaceArray = Wpimporter::get('replace_array');


### PR DESCRIPTION
This prevents the error "Call to member function getContents() on integer" which is a result of the file attachment being connected via deferred binding because the relationship isn't fully setup at this point in the code.