### PR TITLE
Fix Error about duplicate slug and import aborted bug

### DIFF
--- a/models/Wpimporter.php
+++ b/models/Wpimporter.php
@@ -193,8 +193,10 @@ class Wpimporter extends Model
                                 foreach ($item->category[$i]->attributes() as $key => $value) {
                                     if ($value == 'category') {
                                         //Insert category
-                                        $postCategory = $blogCategory::firstOrCreate(['name' => $item->category[$i]]);
-                                        $postCategory->slug = Str::slug($item->category[$i]);
+                                        $postCategory = $blogCategory::firstOrCreate([
+                                            'name' => $item->category[$i],
+                                            'slug' => Str::slug($item->category[$i])
+                                        ]);
                                         $postCategory->save();
 
                                         // If Pro Blog


### PR DESCRIPTION
By passing in the slug as an attribute to firstOrCreate it ensures that there there will never be duplicate slugs.